### PR TITLE
Debug deployment and post endpoint issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,8 @@
   "name": "wowbuffs",
   "version": "1.0.0",
   "scripts": {
-    "register:commands": "node scripts/register-commands.js"
+    "register:commands": "node scripts/register-commands.js",
+    "invite:url": "node scripts/invite-url.js"
   },
   "dependencies": {
     "node-fetch": "^2.6.7",

--- a/scripts/invite-url.js
+++ b/scripts/invite-url.js
@@ -1,0 +1,38 @@
+#!/usr/bin/env node
+
+/**
+ * Prints an OAuth2 invite URL to add your Discord bot to a server.
+ *
+ * Required env:
+ *  - DISCORD_APP_ID (aka Client ID)
+ * Optional env:
+ *  - DISCORD_PERMISSIONS (default: 3072 i.e., View Channels + Send Messages)
+ *  - DISCORD_SCOPES (default: "bot applications.commands")
+ */
+
+function exitWith(message) {
+  console.error(message);
+  process.exit(1);
+}
+
+const appId = process.env.DISCORD_APP_ID;
+if (!appId) exitWith("Please set DISCORD_APP_ID (your application's Client ID).");
+
+const defaultPermissions = "3072"; // VIEW_CHANNEL (1024) + SEND_MESSAGES (2048)
+const permissions = String(process.env.DISCORD_PERMISSIONS || defaultPermissions);
+
+const defaultScopes = ["bot", "applications.commands"];
+const scopes = String(process.env.DISCORD_SCOPES || defaultScopes.join(" "));
+
+const base = "https://discord.com/api/oauth2/authorize";
+const params = new URLSearchParams({
+  client_id: appId,
+  scope: scopes,
+  permissions,
+});
+
+const url = `${base}?${params.toString()}`;
+
+console.log("Discord bot invite URL:\n");
+console.log(url);
+console.log("\nInstructions:\n- Open the URL in a browser.\n- Choose your test server.\n- Ensure the bot role has 'View Channels' and 'Send Messages' in target channels if you set DISCORD_CHANNEL_IDS.");


### PR DESCRIPTION
Add `npm run invite:url` script to generate a Discord bot invite URL, simplifying bot installation to test servers.

---
<a href="https://cursor.com/background-agent?bcId=bc-8b8ba4a7-8503-4ee8-bce4-49400caf84dd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-8b8ba4a7-8503-4ee8-bce4-49400caf84dd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

